### PR TITLE
feat: Dump import files alongside source files. ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.stack-work
 /dist-newstyle
 /cabal.project.local
+/.tags.lock
+/tags
+*.full-imports

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # om-plugin-imports
 
 This plugin behaves similarly to the native GHC options
-`-ddump-minimal-imports`. If (and only if) you specify a `-dumpdir` directory
-to GHC, this plugin will emit files to that directory that contain a
-normalized, complete set of explicit imports for your module. This is sort of
-what `-ddump-minimal-imports` does, but `-ddump-minimal-imports` has the
-following deficiencies:
+`-ddump-minimal-imports`.  It will dump a file of the form
+`<src-file>.full-imports`. E.g. if the Haskell file was `src/Foo/Bar.hs`,
+then the dump file will be `src/Foo/Bar.hs.full-imports`.  The file will
+contain a set of imports which can be copy/pasted over the imports in
+your module in a way that satisfies `-Wmissing-import-lists`.
+
+
+This is _almost_ what `-ddump-minimal-imports` does, but
+`-ddump-minimal-imports` has the following deficiencies:
 
 * It will not always produce output that satisfies `-Wmissing-import-lists`.
   E.g. it will sometimes produce something like:
@@ -18,10 +22,4 @@ following deficiencies:
   ```
   import qualified Foo as F (foo, bar, baz)
   ```
-
-This plugin solves these problems. It will dump
-a file in the user-supplied `-dumpdir` of the form
-`<dumpdir>/<module-name>.full-imports`. The file will contain a set of
-imports which can be copy/pasted over the imports in your module in a
-way that satisfies `-Wmissing-import-lists`.
 

--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -20,11 +20,11 @@ constraints: any.array ==0.5.6.0,
              any.pretty ==1.1.3.6,
              any.process ==1.6.18.0,
              any.rts ==1.0.2,
-             any.safe ==0.3.19,
+             any.safe ==0.3.20,
              any.semaphore-compat ==1.0.0,
              any.stm ==2.5.2.1,
              any.template-haskell ==2.21.0.0,
              any.time ==1.12.2,
              any.transformers ==0.6.1.0,
              any.unix ==2.8.3.0
-index-state: hackage.haskell.org 2023-12-10T16:55:29Z
+index-state: hackage.haskell.org 2024-01-14T19:40:49Z

--- a/om-plugin-imports.cabal
+++ b/om-plugin-imports.cabal
@@ -42,10 +42,10 @@ common warnings
 
 library
   import: dependencies, warnings
-  exposed-modules:     
+  exposed-modules:
     OM.Plugin.Imports
-  -- other-modules:       
-  -- other-extensions:    
+  -- other-modules:
+  -- other-extensions:
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/om-plugin-imports.cabal
+++ b/om-plugin-imports.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                om-plugin-imports
-version:             0.1.0.5
+version:             0.2.0.0
 synopsis:            Plugin-based import warnings
 description:         This is a plutin that acts similar to
                      `-ddump-minimal-imports`, but the style

--- a/src/OM/Plugin/Imports.hs
+++ b/src/OM/Plugin/Imports.hs
@@ -17,8 +17,8 @@ import Data.IORef (readIORef)
 import Data.List (intercalate)
 import Data.Map (Map)
 import Data.Set (Set)
-import GHC (DynFlags(dumpDir), ModSummary, ModuleName, Name, moduleName,
-  moduleNameString)
+import GHC (ModSummary(ms_hspp_file), DynFlags, ModuleName, Name,
+  moduleName)
 import GHC.Data.Bag (bagToList)
 import GHC.Plugins (GlobalRdrEltX(GRE, gre_imp, gre_name, gre_par),
   HasDynFlags(getDynFlags), ImpDeclSpec(ImpDeclSpec, is_as, is_mod,
@@ -28,9 +28,13 @@ import GHC.Plugins (GlobalRdrEltX(GRE, gre_imp, gre_name, gre_par),
   bestImport, defaultPlugin, liftIO, moduleEnvToList, nonDetOccEnvElts,
   showSDoc)
 import GHC.Tc.Utils.Monad (ImportAvails(imp_mods), TcGblEnv(tcg_imports,
-  tcg_mod, tcg_used_gres), MonadIO, TcM)
+  tcg_used_gres), MonadIO, TcM)
 import GHC.Unit.Module.Imported (ImportedBy(ImportedByUser),
   ImportedModsVal(imv_all_exports))
+import Prelude (Applicative(pure), Bool(False, True), Eq((==)),
+  Maybe(Just, Nothing), Monoid(mempty), Semigroup((<>)), ($), (.),
+  (<$>), (||), FilePath, Ord, String, concat, otherwise, putStrLn,
+  unlines, writeFile)
 import Safe (headMay)
 import qualified Data.Char as Char
 import qualified Data.List.NonEmpty as NonEmpty
@@ -50,37 +54,27 @@ typeCheckResultActionImpl
   -> ModSummary
   -> TcGblEnv
   -> TcM TcGblEnv
-typeCheckResultActionImpl _ _ env = do
+typeCheckResultActionImpl _ modSummary env = do
+  liftIO (putStrLn (ms_hspp_file modSummary))
   used <- getUsedImports env
   flags <- getDynFlags
-  void $ writeToDumpFile env flags used
+  void $ writeToDumpFile (ms_hspp_file modSummary) flags used
   pure env
 
 
 writeToDumpFile
   :: (MonadIO m)
-  => TcGblEnv
+  => FilePath
   -> DynFlags
   -> Map ModuleImport (Map Name (Set Name))
   -> m (Maybe FilePath)
-writeToDumpFile env flags used =
-  {-
-    If `-dumpdir` has been specified, then write the output into
-    the dumpdir.  Mainly this  is because I can't figure out how to
-    programmatically find the default dump dir.
-  -}
-  case dumpDir flags of
-    Nothing -> pure Nothing
-    Just dir ->
-      liftIO $ do
-        let
-          modName :: FilePath
-          modName = moduleNameString . moduleName . tcg_mod $ env
-
-          filename :: FilePath
-          filename = dir <> "/" <> modName <> ".full-imports"
-        writeFile filename (renderNewImports flags used)
-        pure (Just filename)
+writeToDumpFile srcFile flags used =
+  liftIO $ do
+    let
+      filename :: FilePath
+      filename = srcFile <> ".full-imports"
+    writeFile filename (renderNewImports flags used)
+    pure (Just filename)
 
 
 getUsedImports


### PR DESCRIPTION
This commit changes the location of where the *.full-imports files
are dumped. Instead of being put in a possibly opaque and difficult to
configure -dumpdir, the files are dumped right along side the source
files to which they are relevant.