### PR TITLE
feat: Add timing output. ...

### DIFF
--- a/om-plugin-imports.cabal
+++ b/om-plugin-imports.cabal
@@ -21,6 +21,7 @@ common dependencies
     , containers >= 0.6.8    && < 0.8
     , ghc        >= 9.8.1    && < 9.11
     , safe       >= 0.3.19   && < 0.4
+    , time       >= 1.12.2   && < 1.13
 
 common warnings
   ghc-options:

--- a/om-plugin-imports.cabal
+++ b/om-plugin-imports.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                om-plugin-imports
-version:             0.4.0.0.9.10
+version:             0.4.0.1.9.10
 synopsis:            Plugin-based explicit import generation.
 description:         See the README at https://github.com/owensmurray/om-plugin-imports/tree/master/#om-plugin-imports
 homepage:            https://github.com/owensmurray/om-plugin-imports

--- a/src/OM/Plugin/Imports.hs
+++ b/src/OM/Plugin/Imports.hs
@@ -18,6 +18,7 @@ import Data.IORef (readIORef)
 import Data.List (intercalate)
 import Data.Map (Map)
 import Data.Set (Set, member)
+import Data.Time (diffUTCTime, getCurrentTime)
 import GHC (ModSummary(ms_hspp_file), DynFlags, ModuleName, Name, moduleName)
 import GHC.Data.Bag (bagToList)
 import GHC.Plugins
@@ -38,8 +39,8 @@ import GHC.Unit.Module.Imported
 import Prelude
   ( Applicative(pure), Bool(False, True), Eq((==)), Foldable(elem)
   , Maybe(Just, Nothing), Monoid(mempty), Num((+)), Ord((>)), Semigroup((<>))
-  , ($), (.), (<$>), (||), FilePath, Int, String, concat, otherwise, putStrLn
-  , unlines, writeFile
+  , Show(show), ($), (.), (<$>), (||), FilePath, Int, String, concat, otherwise
+  , putStr, putStrLn, unlines, writeFile
   )
 import Safe (headMay)
 import qualified Data.Char as Char
@@ -66,13 +67,17 @@ typeCheckResultActionImpl
   -> TcGblEnv
   -> TcM TcGblEnv
 typeCheckResultActionImpl args modSummary env = do
-  liftIO . putStrLn $
+  startTime <- liftIO getCurrentTime
+  liftIO . putStr $
     "Generating imports for file: "
     <> ms_hspp_file modSummary
+    <> "..."
   let options = parseOptions args
   used <- getUsedImports env
   flags <- getDynFlags
   void $ writeToDumpFile options (ms_hspp_file modSummary) flags used
+  endTime <- liftIO getCurrentTime
+  liftIO (putStrLn (" in " <> show (diffUTCTime endTime startTime)))
   pure env
 
 

--- a/src/OM/Plugin/Imports.hs
+++ b/src/OM/Plugin/Imports.hs
@@ -66,7 +66,9 @@ typeCheckResultActionImpl
   -> TcGblEnv
   -> TcM TcGblEnv
 typeCheckResultActionImpl args modSummary env = do
-  liftIO (putStrLn ("Generating imports for file: " <> ms_hspp_file modSummary))
+  liftIO . putStrLn $
+    "Generating imports for file: "
+    <> ms_hspp_file modSummary
   let options = parseOptions args
   used <- getUsedImports env
   flags <- getDynFlags
@@ -116,7 +118,11 @@ getUsedImports env = do
         | (m, ibs)
             <- moduleEnvToList . imp_mods . tcg_imports $ env
         , ImportedByUser imv <- ibs
-        , GRE { gre_name = name } <- concat . nonDetOccEnvElts . imv_all_exports $ imv
+        , GRE { gre_name = name } <-
+            concat
+            . nonDetOccEnvElts
+            . imv_all_exports
+            $ imv
         ]
 
     used :: Map ModuleImport (Map Name (Set Name))


### PR DESCRIPTION
Add how long it takes to generate the imports. Some modules can take a
long time to build, and the plugin output is unfortunately placed
where no other output can happen for a long time, leading to the
mistaken impression that this plugin can add significant time to the
build.