### PR TITLE
fix: Fix pattern synonym imports in plugin

### DIFF
--- a/om-plugin-imports.cabal
+++ b/om-plugin-imports.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                om-plugin-imports
-version:             0.4.0.1.9.12
+version:             0.4.0.2.9.12
 synopsis:            Plugin-based explicit import generation.
 description:         See the README at https://github.com/owensmurray/om-plugin-imports/tree/master/#om-plugin-imports
 homepage:            https://github.com/owensmurray/om-plugin-imports
@@ -54,5 +54,3 @@ test-suite om-plugin-imports-test
     , tasty
     , tasty-golden
     , process
-
-

--- a/om-plugin-imports.cabal
+++ b/om-plugin-imports.cabal
@@ -40,4 +40,19 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
+test-suite om-plugin-imports-test
+  import: dependencies, warnings
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      tests
+  default-language:    Haskell2010
+  main-is:             main.hs
+  build-depends:
+    , om-plugin-imports
+    , directory
+    , filepath
+    , text
+    , tasty
+    , tasty-golden
+    , process
+
 

--- a/tests/golden/AmbiguousUser.full-imports
+++ b/tests/golden/AmbiguousUser.full-imports
@@ -1,0 +1,3 @@
+import Prelude (Num((+)), Int)
+import qualified AmbiguousA as M (foo)
+import qualified AmbiguousB as M (bar)

--- a/tests/golden/Basic.full-imports
+++ b/tests/golden/Basic.full-imports
@@ -1,0 +1,2 @@
+import Data.Maybe (mapMaybe)
+import Prelude (Num((+)), Foldable(foldl'), Int, Maybe, id)

--- a/tests/golden/PatternSynonym.full-imports
+++ b/tests/golden/PatternSynonym.full-imports
@@ -1,0 +1,2 @@
+import PatternSynonymDef (pattern MyPattern)
+import Prelude (Bool(False, True), Int)

--- a/tests/golden/Qualified.full-imports
+++ b/tests/golden/Qualified.full-imports
@@ -1,0 +1,2 @@
+import Prelude (Int)
+import qualified Data.Set as Set

--- a/tests/main.hs
+++ b/tests/main.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import qualified OM.Plugin.Imports as Plugin
+import Test.Tasty (defaultMain, TestTree, testGroup)
+import Test.Tasty.Golden (goldenVsFileDiff)
+import System.FilePath ((</>), takeBaseName, (<.>))
+import System.Directory (listDirectory)
+import Data.List (isSuffixOf, sort)
+import GHC
+  ( runGhc, getSessionDynFlags, setSessionDynFlags, getSession, setSession
+  , guessTarget, setTargets, load, LoadHowMuch(LoadAllTargets)
+  , DynFlags(backend, ghcLink, importPaths), GhcLink(NoLink)
+  )
+import GHC.Driver.Env (HscEnv(hsc_plugins))
+import GHC.Driver.Plugins
+  ( StaticPlugin(StaticPlugin, spInitialised, spPlugin)
+  , PluginWithArgs(PluginWithArgs)
+  , Plugins(staticPlugins)
+  )
+import GHC.Driver.Backend (noBackend)
+import Control.Monad (void)
+import System.Process (readProcess)
+
+main :: IO ()
+main = do
+  libdir <- initGhc
+  testFiles <- findTestFiles
+  defaultMain (testGroup "Golden Tests" (mkTest libdir <$> testFiles))
+
+initGhc :: IO FilePath
+initGhc = do
+  out <- readProcess "ghc" ["--print-libdir"] ""
+  return (init out)
+
+findTestFiles :: IO [FilePath]
+findTestFiles = do
+  files <- listDirectory "tests/samples"
+  return $ sort
+    [ "tests/samples" </> f
+    | f <- files
+    , ".hs" `isSuffixOf` f
+    , f `notElem`
+        [ "PatternSynonymDef.hs"
+        , "AmbiguousA.hs"
+        , "AmbiguousB.hs"
+        ]
+    ]
+
+mkTest :: FilePath -> FilePath -> TestTree
+mkTest libdir srcFile =
+  goldenVsFileDiff
+    (takeBaseName srcFile)
+    (\ref new -> ["diff", "-u", ref, new])
+    goldenFile
+    outFile
+    (runGhcPlugin libdir srcFile)
+  where
+    goldenFile = "tests/golden" </> (takeBaseName srcFile <.> "full-imports")
+    outFile = srcFile <.> "full-imports"
+
+runGhcPlugin :: FilePath -> FilePath -> IO ()
+runGhcPlugin libdir srcFile = do
+    runGhc (Just libdir) $ do
+        dflags <- getSessionDynFlags
+        let dflags' = dflags
+                { importPaths = ["tests/samples"]
+                , backend = noBackend
+                , ghcLink = NoLink
+                }
+        
+        env <- getSession
+        let plugins = hsc_plugins env
+            staticPlugin = StaticPlugin
+                { spPlugin = PluginWithArgs Plugin.plugin []
+                , spInitialised = False
+                }
+            env' = env { hsc_plugins = plugins { staticPlugins = staticPlugin : staticPlugins plugins } }
+        setSession env'
+        
+        void $ setSessionDynFlags dflags'
+        
+        target <- guessTarget srcFile Nothing Nothing
+        setTargets [target]
+        void $ load LoadAllTargets

--- a/tests/samples/AmbiguousA.hs
+++ b/tests/samples/AmbiguousA.hs
@@ -1,0 +1,4 @@
+module AmbiguousA where
+
+foo :: Int
+foo = 1

--- a/tests/samples/AmbiguousB.hs
+++ b/tests/samples/AmbiguousB.hs
@@ -1,0 +1,4 @@
+module AmbiguousB where
+
+bar :: Int
+bar = 2

--- a/tests/samples/AmbiguousUser.hs
+++ b/tests/samples/AmbiguousUser.hs
@@ -1,0 +1,7 @@
+module AmbiguousUser where
+
+import qualified AmbiguousA as M
+import qualified AmbiguousB as M
+
+val :: Int
+val = M.foo + M.bar

--- a/tests/samples/Basic.hs
+++ b/tests/samples/Basic.hs
@@ -1,0 +1,10 @@
+module Basic where
+
+import Data.List (foldl')
+import Data.Maybe (mapMaybe)
+
+foo :: [Int] -> Int
+foo = foldl' (+) 0
+
+bar :: [Maybe Int] -> [Int]
+bar = mapMaybe id

--- a/tests/samples/PatternSynonym.hs
+++ b/tests/samples/PatternSynonym.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE PatternSynonyms #-}
+module PatternSynonym where
+
+import PatternSynonymDef (pattern MyPattern)
+
+test :: Int -> Bool
+test MyPattern = True
+test _ = False

--- a/tests/samples/PatternSynonymDef.hs
+++ b/tests/samples/PatternSynonymDef.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+module PatternSynonymDef where
+
+pattern MyPattern :: Int
+pattern MyPattern = 42

--- a/tests/samples/Qualified.hs
+++ b/tests/samples/Qualified.hs
@@ -1,0 +1,6 @@
+module Qualified where
+
+import qualified Data.Set as Set
+
+foo :: Set.Set Int
+foo = Set.singleton 1


### PR DESCRIPTION
The plugin was previously treating pattern synonyms as regular imports, generating `import M (Pat)` instead of `import M (pattern Pat)`. This commit fixes that by:

1.  Updating `getUsedImports` to look up each imported name in the global environment to check if it's a `PatSynCon`.
2.  Introducing `WrappedName` to store the name along with an `isPattern` flag.
3.  Updating `renderNewImports` to prepend the `pattern` keyword when `isPattern` is true.

This ensures that pattern synonyms are imported correctly, avoiding warnings or errors about missing pattern keywords.