### PR TITLE
Sort import names by displayed string for stable output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented in this file.
 
+## 0.4.1.1.9.14 — 2026-05-31
+
+### Fixed
+
+- **Non-deterministic import ordering**: Parent and child import names are
+  now sorted by their rendered text at print time. GHC's `Name` `Ord`
+  instance uses `nonDetCmpUnique`, so `Set.toAscList` and `Map` key
+  order could vary between compilations.
+
 ## 0.4.1.0.9.14 — 2026-05-28
 
 ### Added

--- a/om-plugin-imports.cabal
+++ b/om-plugin-imports.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                om-plugin-imports
-version:             0.4.1.0.9.14
+version:             0.4.1.1.9.14
 synopsis:            Plugin-based explicit import generation.
 description:         See the README at https://github.com/owensmurray/om-plugin-imports/tree/master/#om-plugin-imports
 homepage:            https://github.com/owensmurray/om-plugin-imports

--- a/src/OM/Plugin/Imports.hs
+++ b/src/OM/Plugin/Imports.hs
@@ -15,7 +15,7 @@ module OM.Plugin.Imports (
 import Control.Exception (evaluate)
 import Control.Monad (void)
 import Data.IORef (readIORef)
-import Data.List (intercalate)
+import Data.List (intercalate, sortOn)
 import Data.Map (Map)
 import Data.Set (Set, member)
 import Data.Time (diffUTCTime, getCurrentTime)
@@ -437,7 +437,8 @@ renderNewImports options flags used =
     showParents parents =
       intercalate ", "
         [ shownWrapped parent <> showChildren children
-        | (parent, children) <- Map.toList parents
+        | (parent, children) <-
+            sortOn (\(parent_, _) -> shownWrapped parent_) (Map.toList parents)
         ]
 
     showChildren :: Set WrappedName -> String
@@ -445,7 +446,11 @@ renderNewImports options flags used =
       if Set.null children then
         ""
       else
-        "(" <> intercalate ", " (shownWrapped <$> Set.toAscList children) <> ")"
+        let
+          sorted :: [WrappedName]
+          sorted = sortOn shownWrapped (Set.toList children)
+        in
+          "(" <> intercalate ", " (shownWrapped <$> sorted) <> ")"
 
     shownWrapped :: WrappedName -> String
     shownWrapped (WrappedName name isPat) =

--- a/tests/golden/AmbiguousUser.full-imports
+++ b/tests/golden/AmbiguousUser.full-imports
@@ -1,3 +1,3 @@
-import Prelude (Num((+)), Int)
+import Prelude (Int, Num((+)))
 import qualified AmbiguousA as M (foo)
 import qualified AmbiguousB as M (bar)

--- a/tests/golden/Basic.full-imports
+++ b/tests/golden/Basic.full-imports
@@ -1,3 +1,3 @@
 import Data.List (intercalate)
 import Data.Maybe (catMaybes, mapMaybe)
-import Prelude (Num((+)), Foldable(foldl'), Char, Int, Maybe, id)
+import Prelude (Char, Foldable(foldl'), Int, Maybe, Num((+)), id)

--- a/tests/golden/Basic.in-place.hs
+++ b/tests/golden/Basic.in-place.hs
@@ -2,7 +2,7 @@ module Basic where
 
 import Data.List (intercalate)
 import Data.Maybe (catMaybes, mapMaybe)
-import Prelude (Num((+)), Foldable(foldl'), Char, Int, Maybe, id)
+import Prelude (Char, Foldable(foldl'), Int, Maybe, Num((+)), id)
 
 foo :: [Int] -> Int
 foo = foldl' (+) 0


### PR DESCRIPTION
GHC's Name Ord uses nonDetCmpUnique, so Set.toAscList and Map key
order could vary between compilations. Sort parent and child names by
their rendered text at print time instead.